### PR TITLE
Rename a GUI that is not specific to custom waypoints

### DIFF
--- a/WaypointManager/CustomWaypointGUI.cs
+++ b/WaypointManager/CustomWaypointGUI.cs
@@ -391,7 +391,7 @@ namespace WaypointManager
         private static void DeleteGUI(int windowID)
         {
             GUILayout.BeginVertical();
-            GUILayout.Label("Delete custom waypoint '" + selectedWaypoint.name + "'?");
+            GUILayout.Label("Delete waypoint '" + selectedWaypoint.name + "'?");
             GUILayout.BeginHorizontal();
             if (GUILayout.Button("Yes"))
             {


### PR DESCRIPTION
DeleteGUI gives a button to "Delete custom waypoint '[waypoint]'?", but DeleteGUI is triggered by deleting any waypoint, not just custom ones.

"Hide Stock Waypoint" calls DeleteWaypoint
https://github.com/linuxgurugamer/WaypointManager/blob/07d3f9d3c129c29d897eccfb62c1a637e4d3538b/WaypointManager/WaypointManager.cs#L489-L492

DeleteWaypoint sets windowMode to WindowMode.Delete
https://github.com/linuxgurugamer/WaypointManager/blob/07d3f9d3c129c29d897eccfb62c1a637e4d3538b/WaypointManager/CustomWaypointGUI.cs#L197-L204

when windowMode = WindowMode.Delete, DeleteGUI is called
https://github.com/linuxgurugamer/WaypointManager/blob/07d3f9d3c129c29d897eccfb62c1a637e4d3538b/WaypointManager/CustomWaypointGUI.cs#L348-L361

https://github.com/linuxgurugamer/WaypointManager/blob/07d3f9d3c129c29d897eccfb62c1a637e4d3538b/WaypointManager/CustomWaypointGUI.cs#L391-L409

Noticed this while checking out https://github.com/linuxgurugamer/WaypointManager/issues/11, although it is entirely unrelated to it.