### PR TITLE
Allow for waypoints named "Site", hide toolbar button in main menu

### DIFF
--- a/WaypointManager/WaypointData.cs
+++ b/WaypointManager/WaypointData.cs
@@ -91,7 +91,7 @@ namespace WaypointManager
             lastCacheUpdate = UnityEngine.Time.fixedTime;
 
             bool changed = false;
-            int cnt = 0;
+            //int cnt = 0;
             // Add new waypoints
             foreach (Waypoint w in FinePrint.WaypointManager.Instance().Waypoints)
             {

--- a/WaypointManager/WaypointData.cs
+++ b/WaypointManager/WaypointData.cs
@@ -103,7 +103,7 @@ namespace WaypointManager
                 Log.Info("name: " + w.name + ", latitude: " + w.latitude + ", longitude: " + w.longitude + ", Altitude: " + w.altitude);
 #endif
                 // Following added to bypass a Kopernicus error where it puts invalid waypoints into the system
-                if (w.name == "Site"  || w.celestialBody.bodyName == "Sun")
+                if (w.celestialBody.bodyName == "Sun")
                     continue;
                 if (w != null && w.isNavigatable)
                 {

--- a/WaypointManager/WaypointManager.cs
+++ b/WaypointManager/WaypointManager.cs
@@ -120,7 +120,8 @@ namespace WaypointManager
             toolbarControl.AddToAllToolbars(ToggleWindow, ToggleWindow,
                 ApplicationLauncher.AppScenes.FLIGHT |
                 ApplicationLauncher.AppScenes.MAPVIEW |
-                ApplicationLauncher.AppScenes.TRACKSTATION,
+                ApplicationLauncher.AppScenes.TRACKSTATION |
+                ~ApplicationLauncher.AppScenes.MAINMENU,
                 MODID,
                 "waypointMgr",
                 "WaypointManager/PluginData/icons/toolbar",


### PR DESCRIPTION
Since all of the bugged waypoints from https://github.com/linuxgurugamer/WaypointManager/issues/11 are on the sun, we can just block any waypoints from being on the sun instead of also blocking any waypoints that have the name of "Site".
Unrelated to this PR, but 2.8.4.7 does still allow you to make waypoints on the sun, it just doesn't put them in the waypoint manager. There could potentially be a future PR that also deletes any waypoints on the sun.

![image](https://github.com/user-attachments/assets/58714e48-8bde-4da6-a66f-e4a25f31d06f)


2.8.4.7 issue where naming a waypoint "Site" would obliterate it from existence (and strangely, it would also obliterate any waypoints of different case than just "Site")
![image](https://github.com/user-attachments/assets/72e231dd-acfd-4a75-b679-d2a56bf877a4)
![image](https://github.com/user-attachments/assets/1f72ad39-9b0b-4488-b035-0f25ac1be110)

Button in main menu (I'm not entirely sure that this is fixed, it shouldn't have been showing in the main menu before anyway, and the main menu buttons seem to be kinda indeterminant on if they want to show up or not):
![image](https://github.com/user-attachments/assets/bb5bda6c-c498-46f0-b7c4-e240faa0322a)
![image](https://github.com/user-attachments/assets/8548fa3d-bba9-42d1-b0a5-7d5a5f25451d)

